### PR TITLE
Add rel attribute to link tag of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ $ npm i dual-listbox --save
 CDN
 ```html
 <script src="https://cdn.jsdelivr.net/npm/dual-listbox/dist/dual-listbox.min.js"></script>
-<link href="https://cdn.jsdelivr.net/npm/dual-listbox/dist/dual-listbox.css">
+<link href="https://cdn.jsdelivr.net/npm/dual-listbox/dist/dual-listbox.css" rel="stylesheet">
 
 <!-- for pinned version -->
 <script src="https://cdn.jsdelivr.net/npm/dual-listbox@1.0.9/dist/dual-listbox.min.js"></script>
-<link href="https://cdn.jsdelivr.net/npm/dual-listbox@1.0.9/dist/dual-listbox.css">
+<link href="https://cdn.jsdelivr.net/npm/dual-listbox@1.0.9/dist/dual-listbox.css" rel="stylesheet">
 ```
 
 ## Usage


### PR DESCRIPTION
The rel attribute of the link tag is insufficient.
In the case of this description, it may not be read in css on the page.